### PR TITLE
print argument enums in help message

### DIFF
--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -260,18 +260,10 @@ class SchemaValidator extends PluginExtensionPoint {
                 def String enums_string = ""
                 if (get_param.enum != null) {
                     def List enums = (List) get_param.enum
-                    def String chop_enums = ""
-                    for (val in enums) {
-                        def String add_val = chop_enums + ", " + val
-                        if (add_val.length() > dec_linewidth - 5) {
-                            chop_enums += ", ..."
-                        } else {
-                            if (chop_enums == "") {
-                                chop_enums += val
-                            } else {
-                                chop_enums += ", " + val
-                            }
-                        }
+                    def String chop_enums = enums.join(", ")
+                    if(chop_enums.length() > dec_linewidth){
+                        chop_enums = chop_enums.substring(0, dec_linewidth-5)
+                        chop_enums = chop_enums.substring(0, chop_enums.lastIndexOf(",")) + ", ..."
                     }
                     enums_string = " (accepted: " + chop_enums + ")"
                 }

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -257,9 +257,27 @@ class SchemaValidator extends PluginExtensionPoint {
                     continue;
                 }
                 def String type = '[' + get_param.type + ']'
+                def String enums_string = ""
+                if (get_param.enum != null) {
+                    def List enums = (List) get_param.enum
+                    def String chop_enums = ""
+                    for (val in enums) {
+                        def String add_val = chop_enums + ", " + val
+                        if (add_val.length() > dec_linewidth - 5) {
+                            chop_enums += ", ..."
+                        } else {
+                            if (chop_enums == "") {
+                                chop_enums += val
+                            } else {
+                                chop_enums += ", " + val
+                            }
+                        }
+                    }
+                    enums_string = " (accepted: " + chop_enums + ")"
+                }
                 def String description = get_param.description
                 def defaultValue = get_param.default != null ? " [default: " + get_param.default.toString() + "]" : ''
-                def description_default = description + colors.dim + defaultValue + colors.reset
+                def description_default = description + colors.dim + enums_string + defaultValue + colors.reset
                 // Wrap long description texts
                 // Loosely based on https://dzone.com/articles/groovy-plain-text-word-wrap
                 if (description_default.length() > dec_linewidth){

--- a/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
@@ -401,6 +401,33 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
         stdout.size == 10
     }
 
+    def 'should print a help message with argument options' () {
+        given:
+        def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()
+        def  SCRIPT_TEXT = """
+            include { paramsHelp } from 'plugin/nf-validation'
+            params.show_hidden_params = true
+
+            def command = "nextflow run <pipeline> --input samplesheet.csv --outdir <OUTDIR> -profile docker"
+            
+            def help_msg = paramsHelp(command, '$schema')
+            log.info help_msg
+        """
+
+        when:
+        dsl_eval(SCRIPT_TEXT)
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('publish_dir_mode') && 
+                    it.contains('(accepted: symlink, rellink, link, copy, copyNoFollow') 
+                    ? it : null }
+
+        then:
+        noExceptionThrown()
+        stdout.size == 1
+    }
+
     def 'should print params summary' () {
         given:
         def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()


### PR DESCRIPTION
Always print the options of an argument with the help message. 

The output with too many options which are chopped looks like this:
<img width="1081" alt="Screenshot 2022-12-13 at 13 21 16" src="https://user-images.githubusercontent.com/8224255/207320490-09b18b8a-b3c3-4069-8b0b-5bf7374fd377.png">
