### PR TITLE
Pass a parameter name to --help to print the complete information

### DIFF
--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -280,6 +280,9 @@ class SchemaValidator extends PluginExtensionPoint {
             }
             output += "--" + param + '\n'
             for (property in get_param) {
+                if (property.key == "fa_icon") {
+                    continue;
+                }
                 def String key = property.key
                 def String value = property.value
                 def Integer lineWidth = 160 - 17

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -276,7 +276,7 @@ class SchemaValidator extends PluginExtensionPoint {
                 }
             }
             if (!get_param) {
-                throw new Exception("Specified param ${param} does not exist in JSON schema.")
+                throw new Exception("Specified param '${param}' does not exist in JSON schema.")
             }
             output += "--" + param + '\n'
             for (property in get_param) {

--- a/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
@@ -401,6 +401,65 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
         stdout.size == 10
     }
 
+    def 'should print a help message of one parameter' () {
+        given:
+        def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()
+        def  SCRIPT_TEXT = """
+            include { paramsHelp } from 'plugin/nf-validation'
+            params.help = 'publish_dir_mode'
+
+            def command = "nextflow run <pipeline> --input samplesheet.csv --outdir <OUTDIR> -profile docker"
+            
+            def help_msg = paramsHelp(command, '$schema')
+            log.info help_msg
+        """
+
+        when:
+        dsl_eval(SCRIPT_TEXT)
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.startsWith('--publish_dir_mode') ||
+                    it.contains('type       :') ||
+                    it.contains('default    :') ||
+                    it.contains('description:') ||
+                    it.contains('help_text  :') ||
+                    it.contains('fa_icon    :') || // fa_icon shouldn't be printed
+                    it.contains('enum       :') ||
+                    it.contains('hidden     :') 
+                    ? it : null }
+
+        then:
+        noExceptionThrown()
+        stdout.size == 7
+    }
+
+    def 'should fail when help param doesnt exist' () {
+        given:
+        def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()
+        def  SCRIPT_TEXT = """
+            include { paramsHelp } from 'plugin/nf-validation'
+            params.help = 'no_exist'
+
+            def command = "nextflow run <pipeline> --input samplesheet.csv --outdir <OUTDIR> -profile docker"
+            
+            def help_msg = paramsHelp(command, '$schema')
+            log.info help_msg
+        """
+
+        when:
+        dsl_eval(SCRIPT_TEXT)
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.startsWith('--no_exist') ? it : null }
+
+        then:
+        def error = thrown(Exception)
+        error.message == "Specified param 'no_exist' does not exist in JSON schema."
+        !stdout
+    }
+
     def 'should print params summary' () {
         given:
         def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()

--- a/plugins/nf-validation/src/testResources/nextflow_schema.json
+++ b/plugins/nf-validation/src/testResources/nextflow_schema.json
@@ -171,7 +171,7 @@
             "help_text": "These options are common to all nf-core pipelines and allow you to customise some of the core preferences for how the pipeline runs.\n\nTypically these options would be set in a Nextflow config file loaded for all pipeline runs, such as `~/.nextflow/config`.",
             "properties": {
                 "help": {
-                    "type": "boolean",
+                    "type": ["string", "boolean"],
                     "description": "Display help text.",
                     "fa_icon": "fas fa-question-circle",
                     "hidden": true


### PR DESCRIPTION
Passing a parameter name to --help will print the complete information for that parameter.

Some examples:

<img width="907" alt="image" src="https://user-images.githubusercontent.com/8224255/208132579-be76bc33-1900-488a-8450-4c3c350acc5f.png">

<img width="1110" alt="image" src="https://user-images.githubusercontent.com/8224255/208132650-3769f3bf-54d2-459b-91b2-2d673833d438.png">

An exception is returned if the parameter doesn't exist

<img width="918" alt="image" src="https://user-images.githubusercontent.com/8224255/208132830-b953d2f0-45cb-46c7-8bf7-2c8cb15d738f.png">
