### PR TITLE
don't check for version param

### DIFF
--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -42,7 +42,6 @@ class SchemaValidator extends PluginExtensionPoint {
             'quiet',
             'syslog',
             'v',
-            'version',
 
             // Options for `nextflow run` command
             'ansi',


### PR DESCRIPTION
Remove `version` form core Nextflow parameters to check. This is done to allow a `--version` option in pipelines which reports the version of the pipeline.
Slack [discussion](https://nfcore.slack.com/archives/CUC8PPDL2/p1677229836508589).