### PR TITLE
change priority to fix the immutable meta bug

### DIFF
--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -156,7 +156,7 @@ class SchemaValidator extends PluginExtensionPoint {
 
         // Set defaults for optional inputs
         def String schemaFilename = options?.containsKey('schema_filename') ? options.schema_filename as String : 'nextflow_schema.json'
-        def Boolean immutableMeta = params.containsKey("validationImmutableMeta") ? params["validationImmutableMeta"] as Boolean : options?.containsKey('immutable_meta') ? options.immutable_meta as Boolean : true
+        def Boolean immutableMeta = options?.containsKey('immutable_meta') ? options.immutable_meta as Boolean : params.containsKey("validationImmutableMeta") ? params["validationImmutableMeta"] as Boolean : true
 
         def slurper = new JsonSlurper()
         def Map parsed = (Map) slurper.parse( Path.of(getSchemaPath(baseDir, schemaFilename)) )


### PR DESCRIPTION
Changes the priority of the immutable meta options, it's now like this:
1. The option of the channel factory `immutable_meta`
2. The parameter specified by the user
3. The default of `true`

This fixes a bug where `validateParameters()` was setting the `validationImmutableMeta` parameter to `true` causing the factory option to break. The reasoning for this change is that if a developer chooses to use the `LinkedHashMap` over the `ImmutableMeta` the user shouldn't change it back as it will almost certainly break everything