### PR TITLE
Print param name when path does not exist

### DIFF
--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -279,7 +279,7 @@ class SchemaValidator extends PluginExtensionPoint {
         def List<String> pathsToCheck = (List) collectExists(schemaParams)
         pathsToCheck.each {
             if (params[it] != null) {
-                pathExists(params[it].toString())
+                pathExists(params[it].toString(), it.toString())
             }
         }
 
@@ -515,7 +515,7 @@ class SchemaValidator extends PluginExtensionPoint {
             for (int i=0; i < arrayJSON.size(); i++) {
                 def JSONObject entry = arrayJSON.getJSONObject(i)
                 if ( entry.has(filedName) ) {
-                    pathExists(entry[filedName].toString())
+                    pathExists(entry[filedName].toString(), fieldName.toString())
                 }
             }
         }
@@ -546,10 +546,10 @@ class SchemaValidator extends PluginExtensionPoint {
     //
     // Function to check if a file or directory exists
     //
-    List pathExists(String path) {
+    List pathExists(String path, String paramName) {
         def Path file = Nextflow.file(path) as Path
         if (!file.exists()) {
-            errors << "* The file or directory '${path}' does not exist.".toString()
+            errors << "* --${paramName}: the file or directory '${path}' does not exist.".toString()
         }
     }
 

--- a/plugins/nf-validation/src/test/nextflow/validation/SamplesheetConverterTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/SamplesheetConverterTest.groovy
@@ -352,8 +352,8 @@ class SamplesheetConverterTest extends Dsl2Spec{
         def error = thrown(SchemaValidationException)
         def errorMessages = error.message.readLines() 
         errorMessages[0] == "\033[0;31mThe following errors have been detected:"
-        errorMessages[2] == "* The file or directory 'non_existing_path' does not exist."
-        errorMessages[3] == "* The file or directory 'non_existing_file.tsv' does not exist."
+        errorMessages[2] == "* --field_9: the file or directory 'non_existing_path' does not exist."
+        errorMessages[3] == "* --field_7: the file or directory 'non_existing_file.tsv' does not exist."
         errorMessages[4] == '* -- Entry 1 - field_7: string [non_existing_file.tsv] does not match pattern ^.*\\.txt$ (non_existing_file.tsv)'
         errorMessages[5] == "* -- Entry 1 - field_8: 'src/testResources/test.txt' is not a directory, but a file (src/testResources/test.txt)"
         errorMessages[6] == "* -- Entry 1 - field_5: expected type: Number, found: String (string)"


### PR DESCRIPTION
When a path (file or directory) doesn't exist, the error message includes the parameter or field name which provided this path.