### PR TITLE
add parameters from schema top level as expected params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # nextflow-io/nf-validation: Changelog
 
+# Version 0.4.0
+
+- Add parameters defined on the top level of the schema and within the definitions section as expected params ([#79](https://github.com/nextflow-io/nf-validation/pull/79))
+
 ## Version 0.3.1
 
 ### Bug fixes

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -281,6 +281,18 @@ class SchemaValidator extends PluginExtensionPoint {
         def enumsTuple = collectEnums(schemaParams)
         def List expectedParams = (List) enumsTuple[0] + addExpectedParams()
         def Map enums = (Map) enumsTuple[1]
+        // Collect expected parameters from the schema when parameters are specified outside of "definitions"
+        if (parsed.containsKey('properties')) {
+            def enumsTupleTopLevel = collectEnums(['top_level': ['properties': parsed.get('properties')]])
+            expectedParams += (List) enumsTupleTopLevel[0]
+            enums += (Map) enumsTupleTopLevel[1]
+        }
+        // Collect expected parameters from the schema when parameters are specified within "definitions"
+        if (schemaParams.containsKey('properties')) {
+            def enumsTupleDefinitions = collectEnums(['definitions': ['properties': schemaParams.get('properties')]])
+            expectedParams += (List) enumsTupleDefinitions[0]
+            enums += (Map) enumsTupleDefinitions[1]
+        }
 
         //=====================================================================//
         // Check if files or directories exist

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -287,12 +287,6 @@ class SchemaValidator extends PluginExtensionPoint {
             expectedParams += (List) enumsTupleTopLevel[0]
             enums += (Map) enumsTupleTopLevel[1]
         }
-        // Collect expected parameters from the schema when parameters are specified within "definitions"
-        if (schemaParams.containsKey('properties')) {
-            def enumsTupleDefinitions = collectEnums(['definitions': ['properties': schemaParams.get('properties')]])
-            expectedParams += (List) enumsTupleDefinitions[0]
-            enums += (Map) enumsTupleDefinitions[1]
-        }
 
         //=====================================================================//
         // Check if files or directories exist


### PR DESCRIPTION
Parameters defined in the schema top level or within `definitions` are considered `expectedParams`.
```json
{
  "$schema": "http://json-schema.org/draft-07/schema",
  "type": "object",
  // Top level params
  "properties": {
    "test_param_1": { 
          "type": "string"
        }
  },
  // Definition groups
  "definitions": { 
    "my_group_of_params": { 
      "title": "A virtual grouping used for docs and pretty-printing",
      "type": "object",
      "required": ["foo", "bar"], 
      "properties": { 
        "foo": { 
          "type": "string"
        },
        "bar": {
          "type": "string"
        }
      }
    },
    // Params within definitions but not inside one of the definitions
    "properties": {
      "test_param_2": { 
        "type": "string"
      }
    }
  },
  // Contents of each definition group brought into main schema for validation
  "allOf": [
    { "$ref": "#/definitions/my_group_of_params" } ,
    { "$ref": "#/definitions" } 
  ]
}
```