### PR TITLE
Remove navigation tabs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,6 @@ theme:
     - content.code.annotate
     - content.code.copy
     - navigation.instant
-    - navigation.tabs
     - navigation.top
     - navigation.tracking
     - navigation.sections


### PR DESCRIPTION
Remove navigation tabs, to find extended documentation easier to find.