### PR TITLE
fix error when a parameter is not present in the schema and evaluates to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug fixes
 
 - Add parameters defined on the top level of the schema and within the definitions section as expected params ([#79](https://github.com/nextflow-io/nf-validation/pull/79))
-- Fix error when a parameter is not present in the schema and evaluates to false ([]())
+- Fix error when a parameter is not present in the schema and evaluates to false ([#89](https://github.com/nextflow-io/nf-validation/pull/89))
 
 ## Version 0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # nextflow-io/nf-validation: Changelog
 
-# Version 0.4.0
+## Version 0.4.0 (dev)
+
+### Bug fixes
 
 - Add parameters defined on the top level of the schema and within the definitions section as expected params ([#79](https://github.com/nextflow-io/nf-validation/pull/79))
+- Fix error when a parameter is not present in the schema and evaluates to false ([]())
 
 ## Version 0.3.1
 

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -316,9 +316,9 @@ class SchemaValidator extends PluginExtensionPoint {
             def isCamelCaseBug = (specifiedParam.contains("-") && !expectedParams.contains(specifiedParam) && expectedParamsLowerCase.contains(specifiedParamLowerCase))
             if (!expectedParams.contains(specifiedParam) && !params_ignore.contains(specifiedParam) && !isCamelCaseBug) {
                 if (failUnrecognisedParams) {
-                    errors << "* --${specifiedParam}: ${paramsJSON[specifiedParam]}".toString()
+                    errors << "* --${specifiedParam}: ${params[specifiedParam]}".toString()
                 } else {
-                    warnings << "* --${specifiedParam}: ${paramsJSON[specifiedParam]}".toString()
+                    warnings << "* --${specifiedParam}: ${params[specifiedParam]}".toString()
                 }
             }
         }


### PR DESCRIPTION
Close #48 and #84 

Use the `params` map to retrieve the value of the specified param instead of `paramsJson` which does not contain parameters evaluating to false.