### PR TITLE
rename the schema_filename option from fromSamplesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # Version 0.4.0
 
 - Add parameters defined on the top level of the schema and within the definitions section as expected params ([#79](https://github.com/nextflow-io/nf-validation/pull/79))
-- Changed the `schema_filename` option of `fromSamplesheet` to `parameters_schema` to make this option more clear to the user.
+- Changed the `schema_filename` option of `fromSamplesheet` to `parameters_schema` to make this option more clear to the user ([#91](https://github.com/nextflow-io/nf-validation/pull/91))
 
 ## Version 0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Version 0.4.0
 
 - Add parameters defined on the top level of the schema and within the definitions section as expected params ([#79](https://github.com/nextflow-io/nf-validation/pull/79))
+- Changed the `schema_filename` option of `fromSamplesheet` to `parameters_schema` to make this option more clear to the user.
 
 ## Version 0.3.1
 

--- a/docs/samplesheets/fromSamplesheet.md
+++ b/docs/samplesheets/fromSamplesheet.md
@@ -23,7 +23,7 @@ The path specified in the `schema` key determines the JSON used for validation o
 
 When using the `.fromSamplesheet` channel factory, some additional optional arguments can be used:
 
-- `schema_filename`: File name for the pipeline parameters schema. (Default: `nextflow_schema.json`)
+- `parameters_schema`: File name for the pipeline parameters schema. (Default: `nextflow_schema.json`)
 - `skip_duplicate_check`: Skip the checking for duplicates. Can also be skipped with the `--validationSkipDuplicateCheck` parameter. (Default: `false`)
 
 ```groovy
@@ -33,7 +33,7 @@ Channel.fromSamplesheet('input')
 ```groovy
 Channel.fromSamplesheet(
   'input',
-  schema_filename: 'custom_nextflow_schema.json',
+  parameters_schema: 'custom_nextflow_schema.json',
   skip_duplicate_check: false
 )
 ```

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -155,7 +155,7 @@ class SchemaValidator extends PluginExtensionPoint {
         def Map params = session.params
 
         // Set defaults for optional inputs
-        def String schemaFilename = options?.containsKey('schema_filename') ? options.schema_filename as String : 'nextflow_schema.json'
+        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
         def Boolean skipDuplicateCheck = options?.containsKey('skip_duplicate_check') ? options.skip_duplicate_check as Boolean : params.validationSkipDuplicateCheck ? params.validationSkipDuplicateCheck as Boolean : false
 
         def slurper = new JsonSlurper()

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -167,10 +167,14 @@ class SchemaValidator extends PluginExtensionPoint {
             throw new SchemaValidationException("", [])
         }
         def Path schemaFile = null
-        if (samplesheetValue != null && samplesheetValue.containsKey('schema')) {
+        if (samplesheetValue == null) {
+            log.error "Parameter '--$samplesheetParam' was not found in the schema ($schemaFilename). Unable to create a channel from it."
+            throw new SchemaValidationException("", [])
+        }
+        else if (samplesheetValue.containsKey('schema')) {
             schemaFile = Path.of(getSchemaPath(baseDir, samplesheetValue['schema'].toString()))
         } else {
-            log.error "Parameter '--$samplesheetParam' does not contain a schema. Unable to create a channel from it."
+            log.error "Parameter '--$samplesheetParam' does not contain a schema in the parameter schema ($schemaFilename). Unable to create a channel from it."
             throw new SchemaValidationException("", [])
         }
 

--- a/plugins/nf-validation/src/test/nextflow/validation/SamplesheetConverterTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/SamplesheetConverterTest.groovy
@@ -64,7 +64,7 @@ class SamplesheetConverterTest extends Dsl2Spec{
             params.input = 'src/testResources/correct.csv'
 
             workflow {
-                Channel.fromSamplesheet("input", schema_filename:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view().first().map {println(it[0].getClass())}
+                Channel.fromSamplesheet("input", parameters_schema:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view().first().map {println(it[0].getClass())}
             }
         '''
 
@@ -90,7 +90,7 @@ class SamplesheetConverterTest extends Dsl2Spec{
             params.input = 'src/testResources/correct.csv'
 
             workflow {
-                Channel.fromSamplesheet("input", schema_filename:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view()
+                Channel.fromSamplesheet("input", parameters_schema:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view()
             }
         '''
 
@@ -116,7 +116,7 @@ class SamplesheetConverterTest extends Dsl2Spec{
             params.input = 'src/testResources/correct.csv'
 
             workflow {
-                Channel.fromSamplesheet("input", schema_filename:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view()
+                Channel.fromSamplesheet("input", parameters_schema:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view()
             }
         '''
 
@@ -142,7 +142,7 @@ class SamplesheetConverterTest extends Dsl2Spec{
             params.input = 'src/testResources/extraFields.csv'
 
             workflow {
-                Channel.fromSamplesheet("input", schema_filename:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view()
+                Channel.fromSamplesheet("input", parameters_schema:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view()
             }
         '''
 
@@ -169,7 +169,7 @@ class SamplesheetConverterTest extends Dsl2Spec{
             params.input = 'src/testResources/no_meta.csv'
 
             workflow {
-                Channel.fromSamplesheet("input", schema_filename:"src/testResources/nextflow_schema_with_samplesheet_no_meta.json").view()
+                Channel.fromSamplesheet("input", parameters_schema:"src/testResources/nextflow_schema_with_samplesheet_no_meta.json").view()
             }
         '''
 
@@ -193,7 +193,7 @@ class SamplesheetConverterTest extends Dsl2Spec{
             params.input = 'src/testResources/errors.csv'
 
             workflow {
-                Channel.fromSamplesheet("input", schema_filename:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view()
+                Channel.fromSamplesheet("input", parameters_schema:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view()
             }
         '''
 
@@ -222,7 +222,7 @@ class SamplesheetConverterTest extends Dsl2Spec{
             params.input = 'src/testResources/errorsBeforeConversion.csv'
 
             workflow {
-                Channel.fromSamplesheet("input", schema_filename:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view()
+                Channel.fromSamplesheet("input", parameters_schema:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view()
             }
         '''
 
@@ -259,7 +259,7 @@ class SamplesheetConverterTest extends Dsl2Spec{
             params.input = 'src/testResources/duplicate.csv'
 
             workflow {
-                Channel.fromSamplesheet("input", schema_filename:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view()
+                Channel.fromSamplesheet("input", parameters_schema:"src/testResources/nextflow_schema_with_samplesheet_converter.json").view()
             }
         '''
 


### PR DESCRIPTION
1. `schema_filename` option from `fromSamplesheet` has been renamed to `parameters_schema` here to make it more clear to the user that it is used for the parameters schema and not for the samplesheet schema.
2. Added an additional check to `fromSamplesheet` that shows an error if the input parameter hasn't been found in the schema