### PR TITLE
Add possibility for direct schema

### DIFF
--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -161,18 +161,16 @@ class SchemaValidator extends PluginExtensionPoint {
         // Get direct schema file
         def String schemaPath = options?.containsKey('schema') ? options.schema as String : null
 
-        // Check for presence of samplesheetParam
+        def slurper = new JsonSlurper()
+        def Map parsed = (Map) slurper.parse( Path.of(getSchemaPath(baseDir, schemaFilename)) )
+        def Map samplesheetValue = (Map) findDeep(parsed, samplesheetParam)
         def Path samplesheetFile = params[samplesheetParam] as Path
         if (samplesheetFile == null) {
             log.error "Parameter '--$samplesheetParam' was not provided. Unable to create a channel from it."
             throw new SchemaValidationException("", [])
         }
 
-        // Get schemaFile
         def Path schemaFile = null
-        def slurper = new JsonSlurper()
-        def Map parsed = (Map) slurper.parse( Path.of(getSchemaPath(baseDir, schemaFilename)) )
-        def Map samplesheetValue = (Map) findDeep(parsed, samplesheetParam)
         if (samplesheetValue == null) {
             log.error "Parameter '--$samplesheetParam' was not found in the schema ($schemaFilename). Unable to create a channel from it."
             throw new SchemaValidationException("", [])

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -170,26 +170,25 @@ class SchemaValidator extends PluginExtensionPoint {
 
         // Get schemaFile
         def Path schemaFile = null
-        if (schemaPath == null) {
-            def slurper = new JsonSlurper()
-            def Map parsed = (Map) slurper.parse( Path.of(getSchemaPath(baseDir, schemaFilename)) )
-            def Map samplesheetValue = (Map) findDeep(parsed, samplesheetParam)
-            if (samplesheetValue == null) {
-                log.error "Parameter '--$samplesheetParam' was not found in the schema ($schemaFilename). Unable to create a channel from it."
-                throw new SchemaValidationException("", [])
-            }
-            else if (samplesheetValue.containsKey('schema')) {
-                schemaFile = Path.of(getSchemaPath(baseDir, samplesheetValue['schema'].toString()))
-            } else {
-                log.error "Parameter '--$samplesheetParam' does not contain a schema in the parameter schema ($schemaFilename). Unable to create a channel from it."
-                throw new SchemaValidationException("", [])
-            }
-        } else {
-            if (options?.containsKey('parameters_schema')) {
+        def slurper = new JsonSlurper()
+        def Map parsed = (Map) slurper.parse( Path.of(getSchemaPath(baseDir, schemaFilename)) )
+        def Map samplesheetValue = (Map) findDeep(parsed, samplesheetParam)
+        if (samplesheetValue == null) {
+            log.error "Parameter '--$samplesheetParam' was not found in the schema ($schemaFilename). Unable to create a channel from it."
+            throw new SchemaValidationException("", [])
+        }
+        else if (samplesheetValue.containsKey('schema')) {
+            if (schemaPath != null) {
                 log.error "Use either parameters_schema or schema."
                 throw new SchemaValidationException("", [])
             }
-            def Path schemaFile = Path.of(getSchemaPath(baseDir, schemaPath.toString()))
+            schemaFile = Path.of(getSchemaPath(baseDir, samplesheetValue['schema'].toString()))
+        } else {
+            if (schemaPath == null) {
+                log.error "Parameter '--$samplesheetParam' does not contain a schema in the parameter schema ($schemaFilename). Unable to create a channel from it."
+                throw new SchemaValidationException("", [])
+            }
+            schemaFile = Path.of(getSchemaPath(baseDir, schemaPath.toString()))
         }
 
         log.debug "Starting validation: '$samplesheetFile' with '$schemaFile'"


### PR DESCRIPTION
The schemaFile value is now settable directly with the parameter schema
This is useful when dynamically set up which json schema to use inside the pipeline

```
if (params.step == "simulate") {
    ch_input = Channel.fromSamplesheet("input", schema : "assets/schema_input_simulate.json")
} else if (params.step == "validate") {
    ch_input = Channel.fromSamplesheet("input", schema : "assets/schema_input_validate.json")
}
```