### PR TITLE
Monochrome logs is option in functions rather than global parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nextflow-io/nf-validation: Changelog
 
+# Version 0.3.4 (dev)
+
+### Bug fixes
+
+- Make monochrome_logs an option in `paramsSummaryLog()`, `paramsSummaryMap()` and `paramsHelp()` instead of a global parameter ([#101](https://github.com/nextflow-io/nf-validation/pull/101))
+
 # Version 0.3.3
 
 ### Bug fixes

--- a/docs/parameters/help_text.md
+++ b/docs/parameters/help_text.md
@@ -79,7 +79,7 @@ params.validationShowHiddenParams = true
 
 By default, the help output is coloured using ANSI escape codes.
 
-If you prefer, you can disable these by using `--monochrome_logs` or `params.monochrome_logs = true`.
+If you prefer, you can disable these by using the argument monochrome_logs, e.g. `paramsHelp(monochrome_logs: true)`. Alternatively this can be set at a global level via parameter `--monochrome_logs` or adding `params.monochrome_logs = true` to a configuration file.
 
 === "Default (coloured)"
 

--- a/docs/parameters/help_text.md
+++ b/docs/parameters/help_text.md
@@ -79,7 +79,7 @@ params.validationShowHiddenParams = true
 
 By default, the help output is coloured using ANSI escape codes.
 
-If you prefer, you can disable these by using the argument monochrome_logs, e.g. `paramsHelp(monochrome_logs: true)`. Alternatively this can be set at a global level via parameter `--monochrome_logs` or adding `params.monochrome_logs = true` to a configuration file.
+If you prefer, you can disable these by using the argument monochrome_logs, e.g. `paramsHelp(monochrome_logs: true)`. Alternatively this can be set at a global level via parameter `--monochrome_logs` or adding `params.monochrome_logs = true` to a configuration file. Not `--monochromeLogs` or `params.monochromeLogs` is also supported.
 
 === "Default (coloured)"
 

--- a/docs/parameters/summary_log.md
+++ b/docs/parameters/summary_log.md
@@ -51,7 +51,7 @@ Output:
 
 By default, the summary output is coloured using ANSI escape codes.
 
-If you prefer, you can disable these by using the argument monochrome_logs, e.g. `paramsSummaryLog(workflow, monochrome_logs: true)`. Alternatively this can be set at a global level via parameter `--monochrome_logs` or adding `params.monochrome_logs = true` to a configuration file.
+If you prefer, you can disable these by using the argument monochrome_logs, e.g. `paramsHelp(monochrome_logs: true)`. Alternatively this can be set at a global level via parameter `--monochrome_logs` or adding `params.monochrome_logs = true` to a configuration file. Not `--monochromeLogs` or `params.monochromeLogs` is also supported.
 
 === "Default (coloured)"
 

--- a/docs/parameters/summary_log.md
+++ b/docs/parameters/summary_log.md
@@ -51,7 +51,7 @@ Output:
 
 By default, the summary output is coloured using ANSI escape codes.
 
-If you prefer, you can disable these by using `--monochrome_logs` or `params.monochrome_logs = true`.
+If you prefer, you can disable these by using the argument monochrome_logs, e.g. `paramsSummaryLog(workflow, monochrome_logs: true)`. Alternatively this can be set at a global level via parameter `--monochrome_logs` or adding `params.monochrome_logs = true` to a configuration file.
 
 === "Default (coloured)"
 

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -260,8 +260,8 @@ class SchemaValidator extends PluginExtensionPoint {
     */
     @Function
     void validateParameters(
-        String schemaFilename,
-        Map options = null
+        Map options = null,
+        String schemaFilename
     ) {
 
         def Map params = initialiseExpectedParams(session.params)

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -220,9 +220,6 @@ class SchemaValidator extends PluginExtensionPoint {
         if( !params.containsKey("validationLenientMode") ) {
             params.validationLenientMode = false
         }
-        if( !params.containsKey("monochrome_logs") ) {
-            params.monochrome_logs = false
-        }
         if( !params.containsKey("help") ) {
             params.help = false
         }
@@ -247,7 +244,6 @@ class SchemaValidator extends PluginExtensionPoint {
         def List expectedParams = [
             "validationFailUnrecognisedParams",
             "validationLenientMode",
-            "monochrome_logs",
             "help",
             "validationShowHiddenParams",
             "validationSchemaIgnoreParams",
@@ -263,7 +259,7 @@ class SchemaValidator extends PluginExtensionPoint {
     * whether the given parameters adhere to the specifications
     */
     @Function
-    void validateParameters(String schema_filename='nextflow_schema.json') {
+    void validateParameters(String schema_filename='nextflow_schema.json', Boolean monochrome_logs=false) {
 
         def Map params = initialiseExpectedParams(session.params)
         def String baseDir = session.baseDir
@@ -346,7 +342,6 @@ class SchemaValidator extends PluginExtensionPoint {
         }
 
         // Colors
-        def Boolean monochrome_logs = params.monochrome_logs
         def colors = logColours(monochrome_logs)
 
         // Validate
@@ -648,10 +643,9 @@ class SchemaValidator extends PluginExtensionPoint {
     // Beautify parameters for --help
     //
     @Function
-    String paramsHelp(String command, String schema_filename='nextflow_schema.json') {
+    String paramsHelp(String command, String schema_filename='nextflow_schema.json', Boolean monochrome_logs=false) {
         def Map params = initialiseExpectedParams(session.params)
         def String baseDir = session.baseDir
-        def Boolean monochrome_logs = params.monochrome_logs
         def colors = logColours(monochrome_logs)
         Integer num_hidden = 0
         String output  = ''
@@ -816,12 +810,11 @@ class SchemaValidator extends PluginExtensionPoint {
     // Beautify parameters for summary and return as string
     //
     @Function
-    public String paramsSummaryLog(WorkflowMetadata workflow, String schema_filename='nextflow_schema.json') {
+    public String paramsSummaryLog(WorkflowMetadata workflow, String schema_filename='nextflow_schema.json', Boolean monochrome_logs=false) {
 
         def String baseDir = session.baseDir
         def Map params = session.params
 
-        def Boolean monochrome_logs = params.monochrome_logs
         def colors = logColours(monochrome_logs)
         String output  = ''
         def LinkedHashMap params_map = paramsSummaryMap(workflow, schema_filename)

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -824,8 +824,8 @@ class SchemaValidator extends PluginExtensionPoint {
     //
     @Function
     public String paramsSummaryLog(
-        WorkflowMetadata workflow,
-        Map options = null
+        Map options = null,
+        WorkflowMetadata workflow
     ) {
 
         def String baseDir = session.baseDir

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -130,11 +130,11 @@ class SchemaValidator extends PluginExtensionPoint {
     //
     // Resolve Schema path relative to main workflow directory
     //
-    static String getSchemaPath(String baseDir, String schema_filename='nextflow_schema.json') {
-        if (Path.of(schema_filename).exists()) {
-            return schema_filename
+    static String getSchemaPath(String baseDir, String schemaFilename='nextflow_schema.json') {
+        if (Path.of(schemaFilename).exists()) {
+            return schemaFilename
         } else {
-            return "${baseDir}/${schema_filename}"
+            return "${baseDir}/${schemaFilename}"
         }
     }
 
@@ -260,13 +260,13 @@ class SchemaValidator extends PluginExtensionPoint {
     */
     @Function
     void validateParameters(
-        Map options = null,
+        Map options = null
     ) {
 
-        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
-        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
         def Map params = initialiseExpectedParams(session.params)
         def String baseDir = session.baseDir
+        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
+        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
         log.debug "Starting parameters validation"
         
         // Clean the parameters
@@ -277,7 +277,7 @@ class SchemaValidator extends PluginExtensionPoint {
         //=====================================================================//
         // Check for nextflow core params and unexpected params
         def slurper = new JsonSlurper()
-        def Map parsed = (Map) slurper.parse( Path.of(getSchemaPath(baseDir, schema_filename)) )
+        def Map parsed = (Map) slurper.parse( Path.of(getSchemaPath(baseDir, schemaFilename)) )
         def Map schemaParams = (Map) parsed.get('definitions')
         def specifiedParamKeys = params.keySet()
 
@@ -329,7 +329,7 @@ class SchemaValidator extends PluginExtensionPoint {
 
         //=====================================================================//
         // Validate parameters against the schema
-        def String schema_string = Files.readString( Path.of(getSchemaPath(baseDir, schema_filename)) )
+        def String schema_string = Files.readString( Path.of(getSchemaPath(baseDir, schemaFilename)) )
         final rawSchema = new JSONObject(new JSONTokener(schema_string))
         final SchemaLoader schemaLoader = SchemaLoader.builder()
                 .schemaJson(rawSchema)
@@ -419,13 +419,13 @@ class SchemaValidator extends PluginExtensionPoint {
     //
     // Function to obtain the variable types of properties from a JSON Schema
     //
-    Map variableTypes(String schema_filename, String baseDir) {
+    Map variableTypes(String schemaFilename, String baseDir) {
         def Map variableTypes = [:]
         def String type = ''
 
         // Read the schema
         def slurper = new JsonSlurper()
-        def Map parsed = (Map) slurper.parse( Path.of(getSchemaPath(baseDir, schema_filename)) )
+        def Map parsed = (Map) slurper.parse( Path.of(getSchemaPath(baseDir, schemaFilename)) )
 
         // Obtain the type of each variable in the schema
         def Map properties = (Map) parsed['items']['properties']
@@ -498,11 +498,11 @@ class SchemaValidator extends PluginExtensionPoint {
     //
     /* groovylint-disable-next-line UnusedPrivateMethodParameter */
     boolean validateFile(
-        Boolean monochrome_logs, String paramName, Object fileContent, String schema_filename, String baseDir
+        Boolean monochrome_logs, String paramName, Object fileContent, String schemaFilename, String baseDir
     ) {
 
         // Load the schema
-        def String schema_string = Files.readString( Path.of(getSchemaPath(baseDir, schema_filename)) )
+        def String schema_string = Files.readString( Path.of(getSchemaPath(baseDir, schemaFilename)) )
         final rawSchema = new JSONObject(new JSONTokener(schema_string))
         final SchemaLoader schemaLoader = SchemaLoader.builder()
             .schemaJson(rawSchema)
@@ -524,7 +524,7 @@ class SchemaValidator extends PluginExtensionPoint {
         //=====================================================================//
         // Check for params with expected values
         def slurper = new JsonSlurper()
-        def Map parsed = (Map) slurper.parse( Path.of(getSchemaPath(baseDir, schema_filename)) )
+        def Map parsed = (Map) slurper.parse( Path.of(getSchemaPath(baseDir, schemaFilename)) )
         def Map schemaParams = (Map) ["items": parsed.get('items')] 
 
         // Collect expected parameters from the schema
@@ -653,17 +653,18 @@ class SchemaValidator extends PluginExtensionPoint {
         Map options = null,
         String command
     ) {
-        // String schema_filename='nextflow_schema.json', Boolean monochrome_logs=false
-        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
-        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
         def Map params = initialiseExpectedParams(session.params)
         def String baseDir = session.baseDir
+
+        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
+        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
+
         def colors = logColours(useMonochromeLogs)
         Integer num_hidden = 0
         String output  = ''
         output        += 'Typical pipeline command:\n\n'
         output        += "  ${colors.cyan}${command}${colors.reset}\n\n"
-        Map params_map = paramsLoad( Path.of(getSchemaPath(baseDir, schema_filename)) )
+        Map params_map = paramsLoad( Path.of(getSchemaPath(baseDir, schemaFilename)) )
         Integer max_chars  = paramsMaxChars(params_map) + 1
         Integer desc_indent = max_chars + 14
         Integer dec_linewidth = 160 - desc_indent
@@ -747,7 +748,7 @@ class SchemaValidator extends PluginExtensionPoint {
     // Groovy Map summarising parameters/workflow options used by the pipeline
     //
     @Function
-    public LinkedHashMap paramsSummaryMap(WorkflowMetadata workflow, String schema_filename='nextflow_schema.json') {
+    public LinkedHashMap paramsSummaryMap(WorkflowMetadata workflow, String schemaFilename='nextflow_schema.json') {
         
         def String baseDir = session.baseDir
         def Map params = session.params
@@ -774,7 +775,7 @@ class SchemaValidator extends PluginExtensionPoint {
 
         // Get pipeline parameters defined in JSON Schema
         def Map params_summary = [:]
-        def Map params_map = paramsLoad( Path.of(getSchemaPath(baseDir, schema_filename)) )
+        def Map params_map = paramsLoad( Path.of(getSchemaPath(baseDir, schemaFilename)) )
         for (group in params_map.keySet()) {
             def sub_params = new LinkedHashMap()
             def Map group_params = params_map.get(group)  as Map // This gets the parameters of that particular group
@@ -827,15 +828,15 @@ class SchemaValidator extends PluginExtensionPoint {
         Map options = null
     ) {
 
-        // String schema_filename='nextflow_schema.json', Boolean monochrome_logs=false
-        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
-        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
         def String baseDir = session.baseDir
         def Map params = session.params
 
+        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
+        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
+
         def colors = logColours(useMonochromeLogs)
         String output  = ''
-        def LinkedHashMap params_map = paramsSummaryMap(workflow, schema_filename)
+        def LinkedHashMap params_map = paramsSummaryMap(workflow, schemaFilename)
         def max_chars  = paramsMaxChars(params_map)
         for (group in params_map.keySet()) {
             def Map group_params = params_map.get(group) as Map // This gets the parameters of that particular group

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -260,12 +260,12 @@ class SchemaValidator extends PluginExtensionPoint {
     */
     @Function
     void validateParameters(
+        String schemaFilename,
         Map options = null
     ) {
 
         def Map params = initialiseExpectedParams(session.params)
         def String baseDir = session.baseDir
-        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
         def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
         log.debug "Starting parameters validation"
         

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -259,8 +259,12 @@ class SchemaValidator extends PluginExtensionPoint {
     * whether the given parameters adhere to the specifications
     */
     @Function
-    void validateParameters(String schema_filename='nextflow_schema.json', Boolean monochrome_logs=false) {
+    void validateParameters(
+        Map options = null,
+    ) {
 
+        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
+        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
         def Map params = initialiseExpectedParams(session.params)
         def String baseDir = session.baseDir
         log.debug "Starting parameters validation"
@@ -342,7 +346,7 @@ class SchemaValidator extends PluginExtensionPoint {
         }
 
         // Colors
-        def colors = logColours(monochrome_logs)
+        def colors = logColours(useMonochromeLogs)
 
         // Validate
         try {
@@ -401,7 +405,7 @@ class SchemaValidator extends PluginExtensionPoint {
                         fileContent = file_path.splitCsv(header:true, strip:true, sep:delimiter)
                         fileContentCasted = castToType(fileContent, types)
                     }
-                    if (validateFile(monochrome_logs, key, fileContentCasted, schema_name, baseDir)) {
+                    if (validateFile(useMonochromeLogs, key, fileContentCasted, schema_name, baseDir)) {
                         log.debug "Validation passed: '$key': '$file_path' with '$schema_name'"
                     }
                 }
@@ -493,7 +497,9 @@ class SchemaValidator extends PluginExtensionPoint {
     // Function to validate a file by its schema
     //
     /* groovylint-disable-next-line UnusedPrivateMethodParameter */
-    boolean validateFile(Boolean monochrome_logs, String paramName, Object fileContent, String schema_filename, String baseDir) {
+    boolean validateFile(
+        Boolean monochrome_logs, String paramName, Object fileContent, String schema_filename, String baseDir
+    ) {
 
         // Load the schema
         def String schema_string = Files.readString( Path.of(getSchemaPath(baseDir, schema_filename)) )
@@ -643,10 +649,16 @@ class SchemaValidator extends PluginExtensionPoint {
     // Beautify parameters for --help
     //
     @Function
-    String paramsHelp(String command, String schema_filename='nextflow_schema.json', Boolean monochrome_logs=false) {
+    String paramsHelp(
+        Map options = null,
+        String command
+    ) {
+        // String schema_filename='nextflow_schema.json', Boolean monochrome_logs=false
+        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
+        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
         def Map params = initialiseExpectedParams(session.params)
         def String baseDir = session.baseDir
-        def colors = logColours(monochrome_logs)
+        def colors = logColours(useMonochromeLogs)
         Integer num_hidden = 0
         String output  = ''
         output        += 'Typical pipeline command:\n\n'
@@ -810,12 +822,18 @@ class SchemaValidator extends PluginExtensionPoint {
     // Beautify parameters for summary and return as string
     //
     @Function
-    public String paramsSummaryLog(WorkflowMetadata workflow, String schema_filename='nextflow_schema.json', Boolean monochrome_logs=false) {
+    public String paramsSummaryLog(
+        WorkflowMetadata workflow,
+        Map options = null
+    ) {
 
+        // String schema_filename='nextflow_schema.json', Boolean monochrome_logs=false
+        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
+        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
         def String baseDir = session.baseDir
         def Map params = session.params
 
-        def colors = logColours(monochrome_logs)
+        def colors = logColours(useMonochromeLogs)
         String output  = ''
         def LinkedHashMap params_map = paramsSummaryMap(workflow, schema_filename)
         def max_chars  = paramsMaxChars(params_map)

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -266,7 +266,10 @@ class SchemaValidator extends PluginExtensionPoint {
 
         def Map params = initialiseExpectedParams(session.params)
         def String baseDir = session.baseDir
-        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
+        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : 
+            params.monochrome_logs ? params.monochrome_logs as Boolean : 
+            params.monochromeLogs  ? params.monochromeLogs as Boolean :
+            false
         log.debug "Starting parameters validation"
         
         // Clean the parameters
@@ -657,7 +660,10 @@ class SchemaValidator extends PluginExtensionPoint {
         def String baseDir = session.baseDir
 
         def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
-        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
+        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : 
+            params.monochrome_logs ? params.monochrome_logs as Boolean : 
+            params.monochromeLogs  ? params.monochromeLogs as Boolean :
+            false
 
         def colors = logColours(useMonochromeLogs)
         Integer num_hidden = 0
@@ -832,7 +838,10 @@ class SchemaValidator extends PluginExtensionPoint {
         def Map params = session.params
 
         def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
-        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : params.monochrome_logs ? params.monochrome_logs as Boolean : false
+        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : 
+            params.monochrome_logs ? params.monochrome_logs as Boolean : 
+            params.monochromeLogs  ? params.monochromeLogs as Boolean :
+            false
 
         def colors = logColours(useMonochromeLogs)
         String output  = ''

--- a/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
@@ -80,7 +80,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.monochrome_logs = true
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('src/testResources/nextflow_schema.json', params.monochrome_logs)
+            validateParameters('src/testResources/nextflow_schema.json', monochrome_logs=params.monochrome_logs)
         """
 
         when:
@@ -226,7 +226,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.validationFailUnrecognisedParams = true
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
         """
 
         when:
@@ -251,7 +251,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.outdir = 10
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
         """
 
         when:
@@ -303,7 +303,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_time = '10.day'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
         """
 
         when:
@@ -378,7 +378,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_cpus = 1.2
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
         """
 
         when:
@@ -404,7 +404,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_memory = '10'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
         """
 
         when:
@@ -616,7 +616,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.input = 'src/testResources/samplesheet_wrong_pattern.csv'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
         """
 
         when:
@@ -640,7 +640,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.input = 'src/testResources/samplesheet_no_required.csv'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
         """
 
         when:

--- a/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
@@ -432,7 +432,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
 
             def command = "nextflow run <pipeline> --input samplesheet.csv --outdir <OUTDIR> -profile docker"
             
-            def help_msg = paramsHelp(command, schema_filename: '$schema')
+            def help_msg = paramsHelp(command, parameters_schema: '$schema')
             log.info help_msg
         """
 
@@ -466,7 +466,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.validationShowHiddenParams = true
             def command = "nextflow run <pipeline> --input samplesheet.csv --outdir <OUTDIR> -profile docker"
             
-            def help_msg = paramsHelp(command, schema_filename: '$schema')
+            def help_msg = paramsHelp(command, parameters_schema: '$schema')
             log.info help_msg
         """
 
@@ -493,7 +493,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
 
             def command = "nextflow run <pipeline> --input samplesheet.csv --outdir <OUTDIR> -profile docker"
             
-            def help_msg = paramsHelp(command, schema_filename: '$schema')
+            def help_msg = paramsHelp(command, parameters_schema: '$schema')
             log.info help_msg
         """
 
@@ -526,7 +526,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
 
             def command = "nextflow run <pipeline> --input samplesheet.csv --outdir <OUTDIR> -profile docker"
             
-            def help_msg = paramsHelp(command, schema_filename: '$schema')
+            def help_msg = paramsHelp(command, parameters_schema: '$schema')
             log.info help_msg
         """
 
@@ -554,7 +554,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.outdir = "outDir"
             include { paramsSummaryLog } from 'plugin/nf-validation'
             
-            def summary_params = paramsSummaryLog(workflow, '$schema')
+            def summary_params = paramsSummaryLog(workflow, parameters_schema: '$schema')
             log.info summary_params
         """
 

--- a/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
@@ -80,7 +80,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.monochrome_logs = true
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('src/testResources/nextflow_schema.json')
+            validateParameters('src/testResources/nextflow_schema.json', params.monochrome_logs)
         """
 
         when:
@@ -226,7 +226,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.validationFailUnrecognisedParams = true
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters('$schema', params.monochrome_logs)
         """
 
         when:
@@ -251,7 +251,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.outdir = 10
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters('$schema', params.monochrome_logs)
         """
 
         when:
@@ -303,7 +303,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_time = '10.day'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters('$schema', params.monochrome_logs)
         """
 
         when:
@@ -378,7 +378,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_cpus = 1.2
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters('$schema', params.monochrome_logs)
         """
 
         when:
@@ -404,7 +404,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_memory = '10'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters('$schema', params.monochrome_logs)
         """
 
         when:
@@ -640,7 +640,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.input = 'src/testResources/samplesheet_no_required.csv'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters('$schema', params.monochrome_logs)
         """
 
         when:

--- a/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
@@ -432,7 +432,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
 
             def command = "nextflow run <pipeline> --input samplesheet.csv --outdir <OUTDIR> -profile docker"
             
-            def help_msg = paramsHelp(command, '$schema')
+            def help_msg = paramsHelp(command, schema_filename: '$schema')
             log.info help_msg
         """
 
@@ -466,7 +466,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.validationShowHiddenParams = true
             def command = "nextflow run <pipeline> --input samplesheet.csv --outdir <OUTDIR> -profile docker"
             
-            def help_msg = paramsHelp(command, '$schema')
+            def help_msg = paramsHelp(command, schema_filename: '$schema')
             log.info help_msg
         """
 
@@ -493,7 +493,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
 
             def command = "nextflow run <pipeline> --input samplesheet.csv --outdir <OUTDIR> -profile docker"
             
-            def help_msg = paramsHelp(command, '$schema')
+            def help_msg = paramsHelp(command, schema_filename: '$schema')
             log.info help_msg
         """
 
@@ -526,7 +526,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
 
             def command = "nextflow run <pipeline> --input samplesheet.csv --outdir <OUTDIR> -profile docker"
             
-            def help_msg = paramsHelp(command, '$schema')
+            def help_msg = paramsHelp(command, schema_filename: '$schema')
             log.info help_msg
         """
 

--- a/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
@@ -80,7 +80,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.monochrome_logs = true
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('src/testResources/nextflow_schema.json', monochrome_logs=params.monochrome_logs)
+            validateParameters('src/testResources/nextflow_schema.json', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -226,7 +226,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.validationFailUnrecognisedParams = true
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -251,7 +251,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.outdir = 10
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -303,7 +303,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_time = '10.day'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -378,7 +378,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_cpus = 1.2
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -404,7 +404,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_memory = '10'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -616,7 +616,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.input = 'src/testResources/samplesheet_wrong_pattern.csv'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -640,7 +640,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.input = 'src/testResources/samplesheet_no_required.csv'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs=params.monochrome_logs)
+            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:


### PR DESCRIPTION
This changes monochrome logs to being an option in paramsSummaryLog(), paramsSummaryMap() and paramsHelp().

This makes the structure more flexible for pipeline developers who can now use params.monochrome_logs or handle it with their own tooling.

Fixes #99
