### PR TITLE
provide schema path through the options map in validateParameters()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # nextflow-io/nf-validation: Changelog
 
+# Version 1.0.0
+
+- The path to a custom parameters schema must be provided through a map '`parameters_schema: 'my_file.json'`' in `validateParameters()` and `paramsSummaryMap()` ([#108](https://github.com/nextflow-io/nf-validation/pull/108))
+
 # Version 0.3.4
 
 ### Bug fixes

--- a/docs/parameters/help_text.md
+++ b/docs/parameters/help_text.md
@@ -79,7 +79,7 @@ params.validationShowHiddenParams = true
 
 By default, the help output is coloured using ANSI escape codes.
 
-If you prefer, you can disable these by using the argument monochrome_logs, e.g. `paramsHelp(monochrome_logs: true)`. Alternatively this can be set at a global level via parameter `--monochrome_logs` or adding `params.monochrome_logs = true` to a configuration file. Not `--monochromeLogs` or `params.monochromeLogs` is also supported.
+If you prefer, you can disable these by using the argument monochrome_logs, e.g. `paramsHelp(monochrome_logs: true)`. Alternatively this can be set at a global level via parameter `--monochrome_logs` or adding `params.monochrome_logs = true` to a configuration file. `--monochromeLogs` or `params.monochromeLogs` is also supported.
 
 === "Default (coloured)"
 

--- a/docs/parameters/validation.md
+++ b/docs/parameters/validation.md
@@ -13,7 +13,7 @@ This function takes all pipeline parameters and checks that they adhere to the s
 - If any parameter validation has failed, it throws a `SchemaValidationException` exception to stop the pipeline.
 - If any parameters in the schema reference a sample sheet schema with `schema`, that file is loaded and validated.
 
-The function takes two optional argument: 
+The function takes two optional arguments:
 
 - The filename of a JSON Schema file (optional, default: `nextflow_schema.json`). File paths should be relative to the root of the pipeline directory.
 - A boolean to disable coloured outputs (optional, default: `false`). The output is coloured using ANSI escape codes by default.

--- a/docs/parameters/validation.md
+++ b/docs/parameters/validation.md
@@ -13,9 +13,18 @@ This function takes all pipeline parameters and checks that they adhere to the s
 - If any parameter validation has failed, it throws a `SchemaValidationException` exception to stop the pipeline.
 - If any parameters in the schema reference a sample sheet schema with `schema`, that file is loaded and validated.
 
-The function takes a single argument: the filename of a JSON Schema file.
-File paths should be relative to the root of the pipeline directory.
-Default: `nextflow_schema.json`.
+The function takes two optional argument: 
+
+- The filename of a JSON Schema file (optional, default: `nextflow_schema.json`). File paths should be relative to the root of the pipeline directory.
+- A boolean to disable coloured outputs (optional, default: `false`). The output is coloured using ANSI escape codes by default.
+
+You can provide the parameters as follows:
+
+```nextflow
+validateParameters(parameters_schema: 'custom_nextflow_parameters.json', monochrome_logs: true)
+```
+
+Monochrome logs can also be set globally providing the parameter `--monochrome_logs` or adding `params.monochrome_logs = true` to a configuration file. The form `--monochromeLogs` is also supported.
 
 !!! tip
 

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -34,7 +34,6 @@ import org.yaml.snakeyaml.Yaml
 import static SamplesheetConverter.getHeader
 import static SamplesheetConverter.getFileType
 
-
 @Slf4j
 @CompileStatic
 class SchemaValidator extends PluginExtensionPoint {
@@ -259,33 +258,22 @@ class SchemaValidator extends PluginExtensionPoint {
     }
 
     /*
-    * Helper function to run validateParameters()
-    * without an options map
-    */
-    @Function
-    void validateParameters(
-        String schemaFilename = 'nextflow_schema.json'
-    ) {
-        validateParameters([:], schemaFilename)
-    }
-
-    /*
     * Function to loop over all parameters defined in schema and check
     * whether the given parameters adhere to the specifications
     */
     @Function
     void validateParameters(
-        Map options = null,
-        String schemaFilename = 'nextflow_schema.json'
+        Map options = null
     ) {
 
         def Map params = initialiseExpectedParams(session.params)
         def String baseDir = session.baseDir
         def Boolean s3PathCheck = params.validationS3PathCheck ? params.validationS3PathCheck : false
-        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : 
+        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean :
             params.monochrome_logs ? params.monochrome_logs as Boolean : 
             params.monochromeLogs  ? params.monochromeLogs as Boolean :
             false
+        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
         log.debug "Starting parameters validation"
         
         // Clean the parameters
@@ -776,8 +764,12 @@ class SchemaValidator extends PluginExtensionPoint {
     // Groovy Map summarising parameters/workflow options used by the pipeline
     //
     @Function
-    public LinkedHashMap paramsSummaryMap(WorkflowMetadata workflow, String schemaFilename='nextflow_schema.json') {
+    public LinkedHashMap paramsSummaryMap(
+        Map options = null,
+        WorkflowMetadata workflow
+        ) {
         
+        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
         def String baseDir = session.baseDir
         def Map params = session.params
         
@@ -860,14 +852,14 @@ class SchemaValidator extends PluginExtensionPoint {
         def Map params = session.params
 
         def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : 'nextflow_schema.json'
-        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean : 
+        def Boolean useMonochromeLogs = options?.containsKey('monochrome_logs') ? options.monochrome_logs as Boolean :
             params.monochrome_logs ? params.monochrome_logs as Boolean : 
             params.monochromeLogs  ? params.monochromeLogs as Boolean :
             false
 
         def colors = logColours(useMonochromeLogs)
         String output  = ''
-        def LinkedHashMap params_map = paramsSummaryMap(workflow, schemaFilename)
+        def LinkedHashMap params_map = paramsSummaryMap(workflow, parameters_schema: schemaFilename)
         def max_chars  = paramsMaxChars(params_map)
         for (group in params_map.keySet()) {
             def Map group_params = params_map.get(group) as Map // This gets the parameters of that particular group

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -258,6 +258,16 @@ class SchemaValidator extends PluginExtensionPoint {
         return expectedParams
     }
 
+    /*
+    * Helper function to run validateParameters()
+    * without an options map
+    */
+    @Function
+    void validateParameters(
+        String schemaFilename = 'nextflow_schema.json'
+    ) {
+        validateParameters([:], schemaFilename)
+    }
 
     /*
     * Function to loop over all parameters defined in schema and check
@@ -266,7 +276,7 @@ class SchemaValidator extends PluginExtensionPoint {
     @Function
     void validateParameters(
         Map options = null,
-        String schemaFilename
+        String schemaFilename = 'nextflow_schema.json'
     ) {
 
         def Map params = initialiseExpectedParams(session.params)

--- a/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
@@ -120,6 +120,9 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
         then:
         noExceptionThrown()
         !stdout
+
+        cleanup:
+        schema_dest.delete()
     }
 
     def 'should validate a schema csv' () {

--- a/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
@@ -80,7 +80,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.monochrome_logs = true
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('src/testResources/nextflow_schema.json', monochrome_logs: params.monochrome_logs)
+            validateParameters(parameters_schema: 'src/testResources/nextflow_schema.json', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -130,7 +130,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.outdir = 'src/testResources/testDir'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters(parameters_schema: '$schema')
         """
 
         when:
@@ -153,7 +153,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.outdir = 'src/testResources/testDir'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters(parameters_schema: '$schema')
         """
 
         when:
@@ -176,7 +176,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.outdir = 'src/testResources/testDir'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters(parameters_schema: '$schema')
         """
 
         when:
@@ -200,7 +200,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.xyz = '/some/path'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters(parameters_schema: '$schema')
         """
 
         when:
@@ -226,7 +226,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.validationSchemaIgnoreParams = 'xyz'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters(parameters_schema: '$schema')
         """
 
         when:
@@ -252,7 +252,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.validationFailUnrecognisedParams = true
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
+            validateParameters(parameters_schema: '$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -277,7 +277,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.outdir = 10
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
+            validateParameters(parameters_schema: '$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -303,7 +303,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_time = '10.day'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters(parameters_schema: '$schema')
         """
 
         when:
@@ -329,7 +329,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_time = '10.day'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
+            validateParameters(parameters_schema: '$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -354,7 +354,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_cpus = 12
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters(parameters_schema: '$schema')
         """
 
         when:
@@ -379,7 +379,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_cpus = '4'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters(parameters_schema: '$schema')
         """
 
         when:
@@ -404,7 +404,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_cpus = 1.2
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
+            validateParameters(parameters_schema: '$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -430,7 +430,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.max_memory = '10'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
+            validateParameters(parameters_schema: '$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -619,7 +619,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.input = 'src/testResources/samplesheet.csv'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema')
+            validateParameters(parameters_schema: '$schema')
         """
 
         when:
@@ -642,7 +642,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.input = 'src/testResources/samplesheet_wrong_pattern.csv'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
+            validateParameters(parameters_schema: '$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:
@@ -666,7 +666,7 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
             params.input = 'src/testResources/samplesheet_no_required.csv'
             include { validateParameters } from 'plugin/nf-validation'
             
-            validateParameters('$schema', monochrome_logs: params.monochrome_logs)
+            validateParameters(parameters_schema: '$schema', monochrome_logs: params.monochrome_logs)
         """
 
         when:

--- a/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
@@ -96,6 +96,32 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
         !stdout
     }
 
+    def 'should validate a schema with no arguments' () {
+        given:
+        def schema_source = new File('src/testResources/nextflow_schema.json')
+        def schema_dest   = new File('nextflow_schema.json')
+        schema_dest << schema_source.text
+
+        def  SCRIPT_TEXT = """
+            params.input = 'src/testResources/correct.csv'
+            params.outdir = 'src/testResources/testDir'
+            include { validateParameters } from 'plugin/nf-validation'
+            
+            validateParameters()
+        """
+
+        when:
+        dsl_eval(SCRIPT_TEXT)
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('* --') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
     def 'should validate a schema csv' () {
         given:
         def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()


### PR DESCRIPTION
All optional parameters are not provided though a map:
`validateParameters(parameters_schema: 'my_params.json')`

The same modification was also made for `paramsSummaryMap()`

⚠️ This will break pipelines who were previously providing a path using the `schemaFilename` argument `validateParameters(schemaFilename = 'my_params.json')`