### PR TITLE
slow validation caused by string replaceAll to remove nulls

### DIFF
--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -2,6 +2,7 @@ package nextflow.validation
 
 import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
+import groovy.json.JsonGenerator
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import groovyx.gpars.dataflow.DataflowWriteChannel
@@ -531,14 +532,12 @@ class SchemaValidator extends PluginExtensionPoint {
             .build()
         final schema = schemaLoader.load().build()
 
-        // Convert the groovy object to a JSONArray
-        def jsonObj = new JsonBuilder(fileContent)
         // Remove all null values from JSON object
-        jsonObj = jsonObj.toString()
-        while (jsonObj.contains("null")) {
-            jsonObj = jsonObj.replaceAll("(.*)(\".*?\":null,?)", '$1')
-        }
-        def JSONArray arrayJSON = new JSONArray(jsonObj)
+        // and convert the groovy object to a JSONArray
+        def jsonGenerator = new JsonGenerator.Options()
+            .excludeNulls()
+            .build()
+        def JSONArray arrayJSON = new JSONArray(jsonGenerator.toJson(fileContent))
 
         //=====================================================================//
         // Check for params with expected values


### PR DESCRIPTION
Fixes #90 

It turns out `replaceAll` to remove `null` values from the json string representation of the samplesheet is the bottleneck here. 

Using `JsonGenerator` with `.excludeNulls` to convert the object to a string and back again to a `JSONArray` solves this. 

Using a single-end samplesheet with 60 rows:

*before*
```
Oct-18 11:57:31.911 [main] DEBUG nextflow.validation.SchemaValidator - Starting validation: 'samplesheet.se.60.csv' with 'assets/schema_input.json'
Oct-18 11:57:31.916 [main] DEBUG nextflow.validation.SchemaValidator - Removing null
Oct-18 12:07:39.610 [main] DEBUG nextflow.validation.SchemaValidator - nulls removed
Oct-18 12:07:39.613 [main] DEBUG nextflow.validation.SchemaValidator - Validation passed: 'samplesheet.se.60.csv' with 'assets/schema_input.json'

```

*after* 
```
Oct-18 12:29:44.364 [main] DEBUG nextflow.validation.SchemaValidator - Starting validation: 'samplesheet.se.60.csv' with 'assets/schema_input.json'
Oct-18 12:29:44.369 [main] DEBUG nextflow.validation.SchemaValidator - Removing null
Oct-18 12:29:44.370 [main] DEBUG nextflow.validation.SchemaValidator - nulls removed
Oct-18 12:29:44.373 [main] DEBUG nextflow.validation.SchemaValidator - Validation passed: 'samplesheet.se.60.csv' with 'assets/schema_input.json'

```

**N.B.** Interestingly it should be noted that if you use a `yaml` input format samplesheet rather than a `csv` you do not see the same issue. This leads me to suspect that `null` values in a `yaml` are being parsed differently at some point before this:
```
Oct-18 11:47:07.491 [main] DEBUG nextflow.validation.SchemaValidator - Starting validation: 'samplesheet.se.60.yaml' with 'assets/schema_input.json'
Oct-18 11:47:07.502 [main] DEBUG nextflow.validation.SchemaValidator - Removing null
Oct-18 11:47:07.503 [main] DEBUG nextflow.validation.SchemaValidator - nulls removed
Oct-18 11:47:07.503 [main] DEBUG nextflow.validation.SchemaValidator - Validation passed: 'samplesheet.se.60.yaml' with 'assets/schema_input.json'

``` 