### PR TITLE
Add make install rule to make dev work easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-
 config ?= compileClasspath
+version ?= $(shell grep 'Plugin-Version' plugins/nf-validation/src/resources/META-INF/MANIFEST.MF | awk '{ print $$2 }')
 
 ifdef module 
 mm = :${module}:
 else 
-mm = 
-endif 
+mm =
+endif
+
+NXF_HOME ?= $$HOME/.nextflow
+NXF_PLUGINS_DIR ?= $(NXF_HOME)/plugins
 
 clean:
 	./gradlew clean
@@ -14,10 +17,8 @@ compile:
 	./gradlew compileGroovy
 	@echo "DONE `date`"
 
-
 check:
 	./gradlew check
-
 
 #
 # Show dependencies try `make deps config=runtime`, `make deps config=google`
@@ -44,14 +45,16 @@ else
 	./gradlew ${mm}test --tests ${class}
 endif
 
-
+install:
+	./gradlew copyPluginZip
+	rm -rf ${NXF_PLUGINS_DIR}/nf-validation-${version}
+	cp -r build/plugins/nf-validation-${version} ${NXF_PLUGINS_DIR}
 
 #
 # Upload JAR artifacts to Maven Central
 #
 upload:
 	./gradlew upload
-
 
 upload-plugins:
 	./gradlew plugins:upload

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -17,30 +17,18 @@ To compile and run the tests use the following command:
 
 To test with Nextflow for development purpose:
 
-Clone the Nextflow repo into a sibling directory
+Compile and install the plugin code
 
 ```bash
-cd .. && git clone https://github.com/nextflow-io/nextflow
-cd nextflow && ./gradlew exportClasspath
+make compile
+make install
 ```
 
-Append to the `settings.gradle` in this project the following line:
+!!! warning
 
-```bash
-includeBuild('../nextflow')
-```
-
-Compile the plugin code
-
-```bash
-./gradlew compileGroovy
-```
-
-Run nextflow with this command:
-
-```bash
-./launch.sh run -plugins nf-validation <script/pipeline name> [pipeline params]
-```
+    This installs the compiled plugin code into your `${HOME}/.nextflow/plugins`
+    directory. If the manifest version of your dev code matches an existing plugin any
+    install will be overwritten.
 
 ## Change and preview the docs
 

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -56,6 +56,14 @@ make compile
 make install
 ```
 
+Then run `nextflow` as normal and specifying your plugin version in your config e.g.
+
+```
+plugins {
+    id 'nf-validation@1.1.1'
+}
+```
+
 ## Change and preview the docs
 
 The docs are generated using [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/).

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -17,18 +17,44 @@ To compile and run the tests use the following command:
 
 To test with Nextflow for development purpose:
 
+Clone the Nextflow repo into a sibling directory
+
+```bash
+cd .. && git clone https://github.com/nextflow-io/nextflow
+cd nextflow && ./gradlew exportClasspath
+```
+
+Append to the `settings.gradle` in this project the following line:
+
+```bash
+includeBuild('../nextflow')
+```
+
+Compile the plugin code
+
+```bash
+./gradlew compileGroovy
+```
+
+Run nextflow with this command:
+
+```bash
+./launch.sh run -plugins nf-validation <script/pipeline name> [pipeline params]
+```
+
+#### Alternative
+
+!!! warning
+
+    This installs the compiled plugin code into your `$NXF_PLUGINS_DIR` (default: `${HOME}/.nextflow/plugins`)
+    directory. If the manifest version of your dev code matches an existing plugin any install will be overwritten.
+
 Compile and install the plugin code
 
 ```bash
 make compile
 make install
 ```
-
-!!! warning
-
-    This installs the compiled plugin code into your `${HOME}/.nextflow/plugins`
-    directory. If the manifest version of your dev code matches an existing plugin any
-    install will be overwritten.
 
 ## Change and preview the docs
 


### PR DESCRIPTION
Implements the `make install` rule from [`nf-prov`](https://github.com/nextflow-io/nf-prov/blob/master/Makefile).

Switches to using `NXF_PLUGINS_DIR` as install location (based on Nextflow logic for deriving that location) but can be overridden on command line like all make variables.