### PR TITLE
Silenced false warnings

### DIFF
--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -405,7 +405,7 @@ class SchemaValidator extends PluginExtensionPoint {
             def Map properties = (Map) group.value['properties']
             for (p in properties) {
                 def String key = (String) p.key
-                if (!params[key]) {
+                if (key.contains(".") || !params[key]) { // ignore nested params with dot operator
                     continue
                 }
                 def Map property = properties[key] as Map

--- a/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/SchemaValidator.groovy
@@ -405,7 +405,7 @@ class SchemaValidator extends PluginExtensionPoint {
             def Map properties = (Map) group.value['properties']
             for (p in properties) {
                 def String key = (String) p.key
-                if (key.contains(".") || !params[key]) { // ignore nested params with dot operator
+                if (key.contains(".") || !params[key]) { // ignore nested params with dot operator => TODO: remove this after adding nested params support
                     continue
                 }
                 def Map property = properties[key] as Map

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,3 +10,4 @@
 rootProject.name = 'nf-validation'
 include 'plugins'
 include('plugins:nf-validation')
+includeBuild('../nextflow')

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,4 +10,3 @@
 rootProject.name = 'nf-validation'
 include 'plugins'
 include('plugins:nf-validation')
-includeBuild('../nextflow')


### PR DESCRIPTION
Parameters listed in nextflow_schema.json that are nested using the dot '.' operator no and are marked as ignored in the nextflow.config longer throw a warning. This fixes to bug mentioned here: https://github.com/nextflow-io/nf-validation/issues/129