### PR TITLE
Bug fix for file path patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nextflow-io/nf-validation: Changelog
 
+# Version 1.1.2 - Wakayama
+
+## Bug fixes
+
+- Fixed an issue with inputs using `file-path-pattern` where only one file was found (`Path` casting to `ArrayList` error) ([#132](https://github.com/nextflow-io/nf-validation/pull/132))
+
 # Version 1.1.1 - Shoyu
 
 ## Bug fixes

--- a/plugins/nf-validation/src/main/nextflow/validation/FormatValidators/FilePathPatternValidator.groovy
+++ b/plugins/nf-validation/src/main/nextflow/validation/FormatValidators/FilePathPatternValidator.groovy
@@ -15,7 +15,7 @@ public class FilePathPatternValidator implements FormatValidator {
             log.debug("S3 paths are not supported by 'FilePathPatternValidator': '${subject}'")
             return Optional.empty()
         }
-        ArrayList files = Nextflow.file(subject) as ArrayList
+        ArrayList files = Nextflow.files(subject)
         ArrayList errors = []
 
         if(files.size() == 0) {
@@ -26,7 +26,7 @@ public class FilePathPatternValidator implements FormatValidator {
                 errors.add("'${file.toString()}' is not a file, but a directory" as String)
             }
         }
-        if(errors.size > 0) {
+        if(errors.size() > 0) {
             return Optional.of(errors.join('\n'))
         }
         return Optional.empty()

--- a/plugins/nf-validation/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-validation/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Id: nf-validation
-Plugin-Version: 1.1.1
+Plugin-Version: 1.1.2
 Plugin-Class: nextflow.validation.ValidationPlugin
 Plugin-Provider: nextflow
 Plugin-Requires: >=22.10.0

--- a/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
+++ b/plugins/nf-validation/src/test/nextflow/validation/PluginExtensionMethodsTest.groovy
@@ -401,6 +401,50 @@ class PluginExtensionMethodsTest extends Dsl2Spec{
         !stdout
     }
 
+    def 'correct validation of file-path-pattern - glob' () {
+        given:
+        def schema = Path.of('src/testResources/nextflow_schema_file_path_pattern.json').toAbsolutePath().toString()
+        def  SCRIPT_TEXT = """
+            params.glob = 'src/testResources/*.csv'
+            include { validateParameters } from 'plugin/nf-validation'
+            
+            validateParameters(parameters_schema: '$schema')
+        """
+
+        when:
+        dsl_eval(SCRIPT_TEXT)
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('* --') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
+    def 'correct validation of file-path-pattern - single file' () {
+        given:
+        def schema = Path.of('src/testResources/nextflow_schema_file_path_pattern.json').toAbsolutePath().toString()
+        def  SCRIPT_TEXT = """
+            params.glob = 'src/testResources/correct.csv'
+            include { validateParameters } from 'plugin/nf-validation'
+            
+            validateParameters(parameters_schema: '$schema')
+        """
+
+        when:
+        dsl_eval(SCRIPT_TEXT)
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('* --') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
     def 'correct validation of numbers with lenient mode' () {
         given:
         def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()

--- a/plugins/nf-validation/src/testResources/nextflow_schema_file_path_pattern.json
+++ b/plugins/nf-validation/src/testResources/nextflow_schema_file_path_pattern.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://raw.githubusercontent.com/nf-core/testpipeline/master/nextflow_schema.json",
+    "title": "nf-core/testpipeline pipeline parameters",
+    "description": "this is a test",
+    "type": "object",
+    "definitions": {
+        "file_patterns": {
+            "title": "Input/output options",
+            "type": "object",
+            "fa_icon": "fas fa-terminal",
+            "properties": {
+                "glob": {
+                    "type": "string",
+                    "format": "file-path-pattern"
+                }
+            }
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "#/definitions/file_patterns"
+        }
+    ]
+}


### PR DESCRIPTION
Bug reported in the `nf-core/mag` pipeline (https://github.com/nf-core/mag/pull/541). When giving a single file as input of a parameter with format `file-path-pattern`, the validator would see it as a `Path` type instead of an `ArrayList` type. By simply changing the `Nextflow.file` function to `Nextflow.files`, an `ArrayList` will always be created.