### PR TITLE
added version:latest to site url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: nf-validation
 repo_name: nextflow-io/nf-validation
 repo_url: https://github.com/nextflow-io/nf-validation
-site_url: https://nextflow-io.github.io/nf-validation/
+site_url: https://nextflow-io.github.io/nf-validation/latest/
 edit_uri: edit/main/docs/
 
 nav:


### PR DESCRIPTION
This PR is related to [this](https://github.com/nf-core/tools/issues/2835#issue-2176505159) issue on the `nf-core/tools` repo. When creating a pipeline with `nf-tools create`, there's a comment added to the main workflow nf file listing a URL that's missing the `/latest/` document version in the URL. After much sleuthing, I suspect the `site_url` variable on the `mkdocs.yml` is the culprit. Adding the latest version of that URL hopefully solves the issue.